### PR TITLE
Add columnOptions.RemoveStandardColumns

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ var log = new LoggerConfiguration()
       "test_db.logs",
       50,
       TimeSpan.FromSeconds(30),
+      new ColumnOptions{
+         RemoveStandardColumns = new List<string>{"level","message"}
+      },
       new List<AdditionalColumn>
       {
           new AdditionalColumn { Name = "source", Type = "String" },
@@ -41,6 +44,9 @@ var log = new LoggerConfiguration()
           "tableName": "test_db.logs",
           "batchPostingLimit": 50,
           "period": "00:00:30",
+          "columnOptions": { 
+            "RemoveStandardColumns": ["level","message"]
+            },
           "additionalColumns": [{
               "Name": "source",
               "Type": "String"

--- a/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/ClickHouseSink.cs
+++ b/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/ClickHouseSink.cs
@@ -14,24 +14,27 @@ namespace Serilog.Sinks.ClickHouse
         private readonly IFormatProvider _formatProvider;
         private readonly ClickHouseProvider<ColumnFormatter> _provider;
         private readonly IEnumerable<AdditionalColumn> _additionalColumns;
+        private readonly ColumnOptions _columnOptions;
 
         public ClickHouseSink(
             string connectionString,
             string tableName,
+            ColumnOptions columnOptions = null,
             IEnumerable<AdditionalColumn> additionalColumns = null,
             IFormatProvider formatProvider = null,
             bool autoCreateSqlTable = true)
         {
+            _columnOptions = columnOptions;
             _additionalColumns = additionalColumns;
             _formatProvider = formatProvider;
-            _provider = new ClickHouseProvider<ColumnFormatter>(tableName, connectionString, additionalColumns, autoCreateSqlTable);
+            _provider = new ClickHouseProvider<ColumnFormatter>(tableName, connectionString, columnOptions, additionalColumns, autoCreateSqlTable);
         }
 
         public async Task EmitBatchAsync(IReadOnlyCollection<LogEvent> events)
         {
             try
             {
-                await _provider.FlushAsync(events.Select(e => new ColumnFormatter(e, _formatProvider, _additionalColumns)));
+                await _provider.FlushAsync(events.Select(e => new ColumnFormatter(e, _formatProvider, _additionalColumns, _columnOptions?.RemoveStandardColumns)));
             }
             catch (Exception ex)
             {

--- a/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/Provider/ClickHouseProvider.cs
+++ b/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/Provider/ClickHouseProvider.cs
@@ -15,6 +15,7 @@ namespace Serilog.Sinks.ClickHouse.Provider
         public ClickHouseProvider(
             string tableName, 
             string connectionString, 
+            ColumnOptions columnOptions = null, 
             IEnumerable<AdditionalColumn> additionalColumns = null, 
             bool autoCreateSqlTable = true)
         {
@@ -24,7 +25,7 @@ namespace Serilog.Sinks.ClickHouse.Provider
             if (string.IsNullOrWhiteSpace(tableName))
                 throw new ArgumentNullException(nameof(tableName));
 
-            _table = new TableHelper<TColumnFormatter>(tableName, additionalColumns);
+            _table = new TableHelper<TColumnFormatter>(tableName, additionalColumns, columnOptions);
             _connectionString = connectionString;
 
             if (autoCreateSqlTable)

--- a/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/Provider/ColumnOptions.cs
+++ b/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/Provider/ColumnOptions.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Serilog.Sinks.ClickHouse.Provider
+{
+    public class ColumnOptions
+    {
+        public IEnumerable<string> RemoveStandardColumns { get; set; }
+    }
+}

--- a/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/Provider/ColumnsHelper.cs
+++ b/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/Provider/ColumnsHelper.cs
@@ -19,14 +19,17 @@ namespace Serilog.Sinks.ClickHouse.Provider
             return dict;
         }
 
-        public static List<PropertyInfo> Props<T>()
+        public static Dictionary<PropertyInfo,ColumnAttribute> Props<T>()
         {
-            var dict = new List<PropertyInfo>();
+            var dict = new Dictionary<PropertyInfo,ColumnAttribute>();
             var props = typeof(T).GetProperties();
             foreach (var p in props)
             {
-                if (p.GetCustomAttribute<ColumnAttribute>() != null)
-                    dict.Add(p);
+                var columnAttribute = p.GetCustomAttribute<ColumnAttribute>();
+                if (columnAttribute != null)
+                {
+                    dict.Add(p,columnAttribute);
+                }
             }
 
             return dict;

--- a/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/Provider/TableHelper.cs
+++ b/Serilog.Sinks.ClickHouse/Sinks/ClickHouse/Provider/TableHelper.cs
@@ -8,9 +8,15 @@ namespace Serilog.Sinks.ClickHouse.Provider
         public string Create { get; private set; }
         public string Insert { get; private set; }
 
-        public TableHelper(string name, IEnumerable<AdditionalColumn> additionalColumns = null)
+        public TableHelper(string name, IEnumerable<AdditionalColumn> additionalColumns = null, ColumnOptions columnOptions = null)
         {
             var mapping = ColumnsHelper.Mapping<T>();
+
+            if (columnOptions?.RemoveStandardColumns != null)
+            {
+                mapping.RemoveAll(x => columnOptions.RemoveStandardColumns.Contains(x.Name));
+            }
+
             if (additionalColumns != null)
                 mapping = mapping.Union(additionalColumns.Select(c => new ColumnAttribute { Name = c.Name, Type = c.Type })).ToList();
 

--- a/Serilog.Sinks.ClickHouse/Sinks/Extensions/ClickHouseSinkExtensions.cs
+++ b/Serilog.Sinks.ClickHouse/Sinks/Extensions/ClickHouseSinkExtensions.cs
@@ -14,6 +14,7 @@ namespace Serilog.Sinks.ClickHouse.Extensions
             string tableName,
             int batchPostingLimit,
             TimeSpan period,
+            ColumnOptions columnOptions = null,
             IEnumerable<AdditionalColumn> additionalColumns = null,
             IFormatProvider formatProvider = null,
             LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose)
@@ -21,6 +22,7 @@ namespace Serilog.Sinks.ClickHouse.Extensions
             var sink = new ClickHouseSink(
                 connectionString,
                 tableName,
+                columnOptions,
                 additionalColumns,
                 formatProvider);
 
@@ -32,6 +34,28 @@ namespace Serilog.Sinks.ClickHouse.Extensions
             };
 
             return loggerConfiguration.Sink(sink, batchingOptions, restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration ClickHouse(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string connectionString,
+            string tableName,
+            int batchPostingLimit,
+            TimeSpan period,
+            IEnumerable<AdditionalColumn> additionalColumns = null,
+            IFormatProvider formatProvider = null,
+            LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose)
+        {
+            return loggerConfiguration.ClickHouse(
+                connectionString,
+                tableName,
+                batchPostingLimit,
+                period,
+                null,
+                additionalColumns,
+                formatProvider,
+                restrictedToMinimumLevel
+            );
         }
     }
 }


### PR DESCRIPTION
1. A columnOptions block has been added to the ClickHouseSink settings. The columnOptions block currently consists of a single element: RemoveStandardColumns.
2. RemoveStandardColumns is a list of standard fields to remove from logs. Standard fields include timestamp, level, message. New standard fields may be added in the future. For example, some users parse properties from message and store them in logs as separate fields. In this case, a separate message field is not needed. The RemoveStandardColumns setting will remove the message field.
3. In the future, it will be possible to add other settings for fields to the columnOptions block - "OrderBy", "PartitionBy", etc.