### PR TITLE
Add AddLogIdColumn with C# and ClickHouse UUID generation

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,11 @@
+## v2.3.0 (Unreleased)
+
+- `SchemaBuilder.AddLogIdColumn()` — adds a unique identifier column for log entries with support for multiple generation strategies:
+    - `CSharpGuid`: generates a standard `Guid.NewGuid()` in C# code (compatible with all ClickHouse versions).
+    - `ClickHouseUUIDv4`: automatically generates a random UUID on the database side using ClickHouse `generateUUIDv4()`.
+    - `ClickHouseUUIDv7`: automatically generates a time-sorted UUIDv7 on the database side using ClickHouse `generateUUIDv7()` (requires ClickHouse 24.1+).
+- Support for DB-generated columns — the sink now automatically excludes columns marked with `SkipWrite` from the `INSERT` statement, allowing ClickHouse to evaluate server-side `DEFAULT` expressions correctly without throwing serialization errors.
+
 ## v2.2.0
 
 - Column-level DDL options: `codec`, `defaultExpression`, `ttl`, and `comment` on all `Add*Column` builder methods, maps to ClickHouse `CODEC(...)`, `DEFAULT expr`, `TTL expr`, and `COMMENT 'text'` clauses

--- a/Serilog.Sinks.ClickHouse.Tests/Integration/ClickHouseSinkIntegrationTests.cs
+++ b/Serilog.Sinks.ClickHouse.Tests/Integration/ClickHouseSinkIntegrationTests.cs
@@ -983,4 +983,107 @@ public class ClickHouseSinkIntegrationTests
         Assert.That(reader.GetString(0), Is.EqualTo("Should still be written"));
         Assert.That(reader.IsDBNull(1), Is.True);
     }
+    
+    [Test]
+    public async Task EmitBatchAsync_WritesGuidFromCSharp_WhenGeneratorIsCSharpGuid()
+    {
+        var table = UniqueTable("guid_csharp");
+        var options = new ClickHouseSinkOptions
+        {
+            ConnectionString = ConnectionString,
+            Schema = new SchemaBuilder()
+                .WithTableName(table)
+                .AddLogIdColumn("log_id", asString: false, generator: LogIdGenerator.CSharpGuid)
+                .AddTimestampColumn()
+                .Build(),
+            TableCreation = new TableCreationOptions { Mode = TableCreationMode.CreateIfNotExists },
+        };
+
+        using var sink = new ClickHouseSink(options);
+        var logEvent = new LogEventBuilder().WithMessage("Test C# Guid").Build();
+
+        await sink.EmitBatchAsync([logEvent]);
+        
+        using var client = new ClickHouseClient(ConnectionString);
+        var reader = await client.ExecuteReaderAsync($"SELECT log_id FROM {SqlGenerator.EscapeTableName(table)} LIMIT 1");
+        
+        Assert.That(reader.Read(), Is.True);
+        var storedGuid = reader.GetGuid(0);
+        
+        Assert.That(storedGuid, Is.Not.EqualTo(Guid.Empty));
+    }
+    
+    [Test]
+    public async Task EmitBatchAsync_AllowsClickHouseToGenerateUuidV4_WithCorrectVersion()
+    {
+        var table = UniqueTable("guid_ch_v4");
+        var options = new ClickHouseSinkOptions
+        {
+            ConnectionString = ConnectionString,
+            Schema = new SchemaBuilder()
+                .WithTableName(table)
+                .AddLogIdColumn("log_id", asString: false, generator: LogIdGenerator.ClickHouseUUIDv4)
+                .AddTimestampColumn()
+                .Build(),
+            TableCreation = new TableCreationOptions { Mode = TableCreationMode.CreateIfNotExists },
+        };
+
+        using var sink = new ClickHouseSink(options);
+        var logEvent = new LogEventBuilder().WithMessage("Test ClickHouse UUIDv4").Build();
+        
+        Assert.DoesNotThrowAsync(() => sink.EmitBatchAsync([logEvent]));
+
+        using var client = new ClickHouseClient(ConnectionString);
+        var reader = await client.ExecuteReaderAsync($"SELECT log_id FROM {SqlGenerator.EscapeTableName(table)} LIMIT 1");
+        
+        Assert.That(reader.Read(), Is.True);
+        var storedGuid = reader.GetGuid(0);
+        
+        Assert.That(storedGuid, Is.Not.EqualTo(Guid.Empty));
+        
+#if NET9_0_OR_GREATER
+        Assert.That(storedGuid.Version, Is.EqualTo(4));
+#else
+        var bytes = storedGuid.ToByteArray();
+        var version = (bytes[7] >> 4) & 0x0F;
+        Assert.That(version, Is.EqualTo(4));
+#endif
+    }
+
+    [Test]
+    public async Task EmitBatchAsync_AllowsClickHouseToGenerateUuidV7_WhenSkipWriteIsTrue()
+    {
+        var table = UniqueTable("guid_ch_v7");
+        var options = new ClickHouseSinkOptions
+        {
+            ConnectionString = ConnectionString,
+            Schema = new SchemaBuilder()
+                .WithTableName(table)
+                .AddLogIdColumn("log_id", asString: false, generator: LogIdGenerator.ClickHouseUUIDv7)
+                .AddTimestampColumn()
+                .Build(),
+            TableCreation = new TableCreationOptions { Mode = TableCreationMode.CreateIfNotExists },
+        };
+
+        using var sink = new ClickHouseSink(options);
+        var logEvent = new LogEventBuilder().WithMessage("Test ClickHouse UUIDv7").Build();
+        
+        Assert.DoesNotThrowAsync(() => sink.EmitBatchAsync([logEvent]));
+        
+        using var client = new ClickHouseClient(ConnectionString);
+        var reader = await client.ExecuteReaderAsync($"SELECT log_id FROM {SqlGenerator.EscapeTableName(table)} LIMIT 1");
+        
+        Assert.That(reader.Read(), Is.True);
+        var storedGuid = reader.GetGuid(0);
+        
+        Assert.That(storedGuid, Is.Not.EqualTo(Guid.Empty));
+        
+#if NET9_0_OR_GREATER
+        Assert.That(storedGuid.Version, Is.EqualTo(7));
+#else
+        var bytes = storedGuid.ToByteArray();
+        var version = (bytes[7] >> 4) & 0x0F;
+        Assert.That(version, Is.EqualTo(7));
+#endif
+    }
 }

--- a/Serilog.Sinks.ClickHouse.Tests/Unit/ColumnWriters/LogIdColumnWriterTests.cs
+++ b/Serilog.Sinks.ClickHouse.Tests/Unit/ColumnWriters/LogIdColumnWriterTests.cs
@@ -1,0 +1,99 @@
+﻿using Serilog.Sinks.ClickHouse.ColumnWriters;
+using Serilog.Sinks.ClickHouse.Schema;
+using Serilog.Sinks.ClickHouse.Tests.Fixtures;
+
+namespace Serilog.Sinks.ClickHouse.Tests.Unit.ColumnWriters;
+
+[TestFixture]
+public class LogIdColumnWriterTests
+{
+    [Test]
+    public void Constructor_DefaultColumnNameIsGuid()
+    {
+        var writer = new LogIdColumnWriter();
+        Assert.That(writer.ColumnName, Is.EqualTo("guid"));
+    }
+
+    [Test]
+    public void Constructor_UsesUuidType_WhenAsStringIsFalse()
+    {
+        var writer = new LogIdColumnWriter(asString: false);
+        Assert.That(writer.ColumnType, Is.EqualTo("UUID"));
+    }
+
+    [Test]
+    public void Constructor_UsesStringType_WhenAsStringIsTrue()
+    {
+        var writer = new LogIdColumnWriter(asString: true);
+        Assert.That(writer.ColumnType, Is.EqualTo("String"));
+    }
+
+    [Test]
+    public void Constructor_AcceptsCustomColumnType()
+    {
+        var writer = new LogIdColumnWriter("my_id", asString: false, columnType: "Nullable(UUID)");
+        Assert.That(writer.ColumnType, Is.EqualTo("Nullable(UUID)"));
+    }
+
+    [Test]
+    public void GetValue_ReturnsGuidStructure_WhenAsStringIsFalse()
+    {
+        var logEvent = new LogEventBuilder().Build();
+        var writer = new LogIdColumnWriter(asString: false);
+
+        var result = writer.GetValue(logEvent);
+
+        Assert.That(result, Is.InstanceOf<Guid>());
+        Assert.That(result, Is.Not.EqualTo(Guid.Empty));
+    }
+
+    [Test]
+    public void GetValue_ReturnsValidGuidString_WhenAsStringIsTrue()
+    {
+        var logEvent = new LogEventBuilder().Build();
+        var writer = new LogIdColumnWriter(asString: true);
+
+        var result = writer.GetValue(logEvent);
+
+        Assert.That(result, Is.InstanceOf<string>());
+        Assert.DoesNotThrow(() => Guid.Parse((string)result!));
+    }
+
+    [Test]
+    public void GetValue_GeneratesUniqueValues_EachTimeCalled()
+    {
+        var logEvent = new LogEventBuilder().Build();
+        var writer = new LogIdColumnWriter(asString: false);
+
+        var result1 = writer.GetValue(logEvent);
+        var result2 = writer.GetValue(logEvent);
+
+        Assert.That(result1, Is.Not.EqualTo(result2));
+    }
+    
+    [Test]
+    public void AddLogIdColumn_WithCSharpGuid_SetsSkipWriteToFalse()
+    {
+        var schema = new SchemaBuilder()
+            .WithTableName("logs")
+            .AddLogIdColumn(generator: LogIdGenerator.CSharpGuid)
+            .Build();
+
+        var column = schema.Columns.First();
+        Assert.That(column.SkipWrite, Is.False);
+    }
+
+    [Test]
+    [TestCase(LogIdGenerator.ClickHouseUUIDv4)]
+    [TestCase(LogIdGenerator.ClickHouseUUIDv7)]
+    public void AddLogIdColumn_WithDbGenerator_SetsSkipWriteToTrue(LogIdGenerator generator)
+    {
+        var schema = new SchemaBuilder()
+            .WithTableName("logs")
+            .AddLogIdColumn(generator: generator)
+            .Build();
+
+        var column = schema.Columns.First();
+        Assert.That(column.SkipWrite, Is.True);
+    }
+}

--- a/Serilog.Sinks.ClickHouse.Tests/Unit/ColumnWriters/LogIdColumnWriterTests.cs
+++ b/Serilog.Sinks.ClickHouse.Tests/Unit/ColumnWriters/LogIdColumnWriterTests.cs
@@ -8,10 +8,10 @@ namespace Serilog.Sinks.ClickHouse.Tests.Unit.ColumnWriters;
 public class LogIdColumnWriterTests
 {
     [Test]
-    public void Constructor_DefaultColumnNameIsGuid()
+    public void Constructor_DefaultColumnNameIsLogId()
     {
         var writer = new LogIdColumnWriter();
-        Assert.That(writer.ColumnName, Is.EqualTo("guid"));
+        Assert.That(writer.ColumnName, Is.EqualTo("log_id"));
     }
 
     [Test]

--- a/Serilog.Sinks.ClickHouse.Tests/Unit/Schema/SchemaBuilderTests.cs
+++ b/Serilog.Sinks.ClickHouse.Tests/Unit/Schema/SchemaBuilderTests.cs
@@ -344,4 +344,86 @@ public class SchemaBuilderTests
         Assert.That(column.Ttl, Is.EqualTo("ts + INTERVAL 7 DAY"));
         Assert.That(column.Comment, Is.EqualTo("Timestamp"));
     }
+    
+    [Test]
+    public void AddLogIdColumn_WithCSharpGuid_AddsLogIdWriterWithCorrectDefaults()
+    {
+        var schema = new SchemaBuilder()
+            .WithTableName("logs")
+            .AddLogIdColumn("log_id", asString: false, generator: LogIdGenerator.CSharpGuid)
+            .Build();
+
+        Assert.That(schema.Columns, Has.Count.EqualTo(1));
+        var column = schema.Columns.First();
+        
+        Assert.That(column, Is.InstanceOf<LogIdColumnWriter>());
+        Assert.That(column.ColumnName, Is.EqualTo("log_id"));
+        Assert.That(column.ColumnType, Is.EqualTo("UUID"));
+        Assert.That(column.Default, Is.Null);
+    }
+
+    [Test]
+    public void AddLogIdColumn_AsString_SetsColumnTypeToString()
+    {
+        var schema = new SchemaBuilder()
+            .WithTableName("logs")
+            .AddLogIdColumn("log_id", asString: true, generator: LogIdGenerator.CSharpGuid)
+            .Build();
+
+        var column = schema.Columns.First();
+        Assert.That(column.ColumnType, Is.EqualTo("String"));
+    }
+
+    [Test]
+    public void AddLogIdColumn_WithClickHouseUUIDv4_SetsDefaultExpression()
+    {
+        var schema = new SchemaBuilder()
+            .WithTableName("logs")
+            .AddLogIdColumn("log_id", asString: false, generator: LogIdGenerator.ClickHouseUUIDv4)
+            .Build();
+
+        var column = schema.Columns.First();
+        Assert.That(column.ColumnType, Is.EqualTo("UUID"));
+        Assert.That(column.Default, Is.EqualTo("generateUUIDv4()"));
+    }
+
+    [Test]
+    public void AddLogIdColumn_WithClickHouseUUIDv4AndAsString_SetsStringDefaultExpression()
+    {
+        var schema = new SchemaBuilder()
+            .WithTableName("logs")
+            .AddLogIdColumn("log_id", asString: true, generator: LogIdGenerator.ClickHouseUUIDv4)
+            .Build();
+
+        var column = schema.Columns.First();
+        Assert.That(column.ColumnType, Is.EqualTo("String"));
+        Assert.That(column.Default, Is.EqualTo("toString(generateUUIDv4())"));
+    }
+
+    [Test]
+    public void AddLogIdColumn_WithClickHouseUUIDv7_SetsDefaultExpression()
+    {
+        var schema = new SchemaBuilder()
+            .WithTableName("logs")
+            .AddLogIdColumn("log_id", asString: false, generator: LogIdGenerator.ClickHouseUUIDv7)
+            .Build();
+
+        var column = schema.Columns.First();
+        Assert.That(column.ColumnType, Is.EqualTo("UUID"));
+        Assert.That(column.Default, Is.EqualTo("generateUUIDv7()"));
+    }
+
+    [Test]
+    public void AddLogIdColumn_SetsOptionalParameters()
+    {
+        var schema = new SchemaBuilder()
+            .WithTableName("logs")
+            .AddLogIdColumn("log_id", codec: "ZSTD(1)", ttl: "timestamp + INTERVAL 1 DAY", comment: "Unique log id")
+            .Build();
+
+        var column = schema.Columns.First();
+        Assert.That(column.Codec, Is.EqualTo("ZSTD(1)"));
+        Assert.That(column.Ttl, Is.EqualTo("timestamp + INTERVAL 1 DAY"));
+        Assert.That(column.Comment, Is.EqualTo("Unique log id"));
+    }
 }

--- a/Serilog.Sinks.ClickHouse/ClickHouseSink.cs
+++ b/Serilog.Sinks.ClickHouse/ClickHouseSink.cs
@@ -7,6 +7,7 @@ using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.ClickHouse.Client;
+using Serilog.Sinks.ClickHouse.ColumnWriters;
 using Serilog.Sinks.ClickHouse.Configuration;
 using Serilog.Sinks.ClickHouse.Schema;
 
@@ -98,12 +99,16 @@ public sealed class ClickHouseSink : IBatchedLogEventSink, IDisposable
                 _tableCreated = true;
             }
 
-            // Transform log events to row arrays using column writers
-            var columns = _options.Schema!.Columns.Select(c => c.ColumnName);
-            var rows = batch.Select(TransformLogEvent);
+            // Filter columns that should be written to the database (excludes DB-generated columns)
+            var writableColumns = _options.Schema!.Columns
+                .Where(c => !c.SkipWrite)
+                .ToList();
+            
+            // Transform log events to row arrays using filtered column writers
+            var columns = writableColumns.Select(c => c.ColumnName);
+            var rows = batch.Select(logEvent => TransformLogEvent(logEvent, writableColumns));
 
             // Bulk insert
-            
             await _client.InsertBinaryAsync(
                 SqlGenerator.EscapeTableName(_options.Schema!.FullTableName),
                 columns,
@@ -149,20 +154,19 @@ public sealed class ClickHouseSink : IBatchedLogEventSink, IDisposable
         }
     }
 
-    private object[] TransformLogEvent(LogEvent logEvent)
+    private object[] TransformLogEvent(LogEvent logEvent, List<ColumnWriterBase> writableColumns)
     {
-        var columns = _options.Schema!.Columns;
-        var values = new object[columns.Count];
+        var values = new object[writableColumns.Count];
 
-        for (var i = 0; i < columns.Count; i++)
+        for (var i = 0; i < writableColumns.Count; i++)
         {
             try
             {
-                values[i] = columns[i].GetValue(logEvent, _formatProvider) ?? DBNull.Value;
+                values[i] = writableColumns[i].GetValue(logEvent, _formatProvider) ?? DBNull.Value;
             }
             catch (Exception ex)
             {
-                SelfLog.WriteLine("Error extracting column '{0}': {1}", columns[i].ColumnName, ex.Message);
+                SelfLog.WriteLine("Error extracting column '{0}': {1}", writableColumns[i].ColumnName, ex.Message);
                 values[i] = DBDefault.Value;
             }
         }

--- a/Serilog.Sinks.ClickHouse/ColumnWriters/ColumnWriterBase.cs
+++ b/Serilog.Sinks.ClickHouse/ColumnWriters/ColumnWriterBase.cs
@@ -54,6 +54,12 @@ public abstract class ColumnWriterBase
     public string? Comment { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether this column should be excluded from the <c>INSERT</c> statement.
+    /// Useful for columns whose values are generated automatically on the database side via <c>DEFAULT</c> expressions.
+    /// </summary>
+    public bool SkipWrite { get; set; }
+    
+    /// <summary>
     /// Initializes a new instance of the <see cref="ColumnWriterBase"/> class.
     /// </summary>
     /// <param name="columnName">The name of the column in the ClickHouse table.</param>

--- a/Serilog.Sinks.ClickHouse/ColumnWriters/LogIdColumnWriter.cs
+++ b/Serilog.Sinks.ClickHouse/ColumnWriters/LogIdColumnWriter.cs
@@ -31,15 +31,15 @@ public enum LogIdGenerator
 
 /// <summary>
 /// Writes the log id.
-/// If asString is true (default), uses String. Otherwise uses UUID.
-/// If columnType is passed, it overrides the above.
+/// If <c>asString</c> is true, uses String. otherwise uses UUID (default).
+/// If <c>columnType</c> is passed, it overrides the above.
 /// </summary>
 public class LogIdColumnWriter : ColumnWriterBase
 {
     private readonly bool _asString;
 
     /// <inheritdoc />
-    public LogIdColumnWriter(string columnName = "guid", bool asString = false, string? columnType = null) 
+    public LogIdColumnWriter(string columnName = "log_id", bool asString = false, string? columnType = null) 
         : base(columnName, columnType ?? (asString ? "String" : "UUID"))
     {
         _asString = asString;

--- a/Serilog.Sinks.ClickHouse/ColumnWriters/LogIdColumnWriter.cs
+++ b/Serilog.Sinks.ClickHouse/ColumnWriters/LogIdColumnWriter.cs
@@ -1,0 +1,59 @@
+﻿using Serilog.Events;
+
+namespace Serilog.Sinks.ClickHouse.ColumnWriters;
+
+
+/// <summary>
+/// Defines the strategy used to generate unique identifiers for log entries.
+/// </summary>
+public enum LogIdGenerator
+{
+    /// <summary>
+    /// Generates a standard <see cref="Guid.NewGuid"/> in the C# application before writing to ClickHouse.
+    /// Compatible with all ClickHouse versions.
+    /// </summary>
+    CSharpGuid,
+    
+    /// <summary>
+    /// Relies on the ClickHouse built-in <c>generateUUIDv4()</c> function. 
+    /// The identifier is generated automatically on the database side during insertion.
+    /// </summary>
+    ClickHouseUUIDv4,
+    
+    /// <summary>
+    /// Relies on the ClickHouse built-in <c>generateUUIDv7()</c> function. 
+    /// Generates time-sorted UUIDs on the database side. 
+    /// Requires ClickHouse version 24.1 or higher.
+    /// </summary>
+    ClickHouseUUIDv7
+}
+
+
+/// <summary>
+/// Writes the log id.
+/// If asString is true (default), uses String. Otherwise uses UUID.
+/// If columnType is passed, it overrides the above.
+/// </summary>
+public class LogIdColumnWriter : ColumnWriterBase
+{
+    private readonly bool _asString;
+
+    /// <inheritdoc />
+    public LogIdColumnWriter(string columnName = "guid", bool asString = false, string? columnType = null) 
+        : base(columnName, columnType ?? (asString ? "String" : "UUID"))
+    {
+        _asString = asString;
+    }
+
+    /// <inheritdoc />
+    public override object? GetValue(LogEvent logEvent, IFormatProvider? formatProvider = null)
+    {
+        if (SkipWrite)
+        {
+            return null; 
+        }
+
+        var guid = Guid.NewGuid();
+        return _asString ? guid.ToString() : guid;
+    }
+}

--- a/Serilog.Sinks.ClickHouse/Schema/SchemaBuilder.cs
+++ b/Serilog.Sinks.ClickHouse/Schema/SchemaBuilder.cs
@@ -56,6 +56,40 @@ public sealed class SchemaBuilder
     }
 
     /// <summary>
+    /// Adds a log id column.
+    /// </summary>
+    /// <param name="name">Column name.</param>
+    /// <param name="asString">If true, uses String. otherwise uses UUID.</param>
+    /// <param name="generator">The strategy to generate unique identifiers.</param>
+    /// <param name="codec">Optional compression codec (e.g. "ZSTD").</param>
+    /// <param name="ttl">Optional column-level TTL expression.</param>
+    /// <param name="comment">Optional column comment.</param>
+    public SchemaBuilder AddLogIdColumn (
+        string name = "log_id",
+        bool asString = false,
+        LogIdGenerator generator = LogIdGenerator.CSharpGuid,
+        string? codec = null,
+        string? ttl = null,
+        string? comment = null)
+    {
+        var finalDefault = generator switch
+        {
+            LogIdGenerator.ClickHouseUUIDv4 => asString ? "toString(generateUUIDv4())" : "generateUUIDv4()",
+            LogIdGenerator.ClickHouseUUIDv7 => asString ? "toString(generateUUIDv7())" : "generateUUIDv7()",
+            _ => null
+        };
+
+        var skipWrite = generator != LogIdGenerator.CSharpGuid;
+        
+        _columns.Add(new LogIdColumnWriter(name, asString)
+        {
+            Codec = codec, Default = finalDefault, Ttl = ttl, Comment = comment, SkipWrite = skipWrite
+        });
+        
+        return this;
+    }
+    
+    /// <summary>
     /// Adds a timestamp column. ClickHouse type: <c>DateTime64({precision})</c>.
     /// </summary>
     /// <param name="name">Column name.</param>

--- a/Serilog.Sinks.ClickHouse/Schema/SchemaBuilder.cs
+++ b/Serilog.Sinks.ClickHouse/Schema/SchemaBuilder.cs
@@ -64,7 +64,7 @@ public sealed class SchemaBuilder
     /// <param name="codec">Optional compression codec (e.g. "ZSTD").</param>
     /// <param name="ttl">Optional column-level TTL expression.</param>
     /// <param name="comment">Optional column comment.</param>
-    public SchemaBuilder AddLogIdColumn (
+    public SchemaBuilder AddLogIdColumn(
         string name = "log_id",
         bool asString = false,
         LogIdGenerator generator = LogIdGenerator.CSharpGuid,


### PR DESCRIPTION
Closes #49

### Description of changes
This PR implements the requested feature to add a unique identifier column for log entries using the Fluent API. Instead of just basic client-side generation, it introduces three flexible strategies:
1. `CSharpGuid` — Generates `Guid.NewGuid()` before sending data (compatible with all CH versions).
2. `ClickHouseUUIDv4` — Relies on database-side `generateUUIDv4()`.
3. `ClickHouseUUIDv7` — Relies on database-side time-sorted `generateUUIDv7()` (requires CH 24.1+).

### Core adjustments
- **`ColumnWriterBase`**: Added a `SkipWrite` property to safely exclude columns from the `INSERT` statement when their values are generated entirely on the ClickHouse side via `DEFAULT` expressions.
- **`ClickHouseSink`**: Optimized batch transformation to filter out `SkipWrite` columns before serialization, preventing `ClickHouseBulkCopySerializationException` caused by passing `null`/`DBNull` to server-side defaults.
- **`RELEASE_NOTES.md`**: Updated with release notes for the upcoming `v2.3.0` version.

### Testing
- Added unit tests for `LogIdColumnWriter` and `SchemaBuilder` configurations.
- Added strict integration tests with a live ClickHouse instance to validate schema creation, `INSERT` behavior, and exact UUID versions (`v4` and `v7`) inside the database.