### PR TITLE
Tag ClickHouse User-Agent with lib identity

### DIFF
--- a/Serilog.Sinks.ClickHouse.Tests/Integration/UserAgentIntegrationTests.cs
+++ b/Serilog.Sinks.ClickHouse.Tests/Integration/UserAgentIntegrationTests.cs
@@ -1,0 +1,47 @@
+using ClickHouse.Driver;
+using Serilog.Sinks.ClickHouse.Configuration;
+using Serilog.Sinks.ClickHouse.Schema;
+using Serilog.Sinks.ClickHouse.Tests.Fixtures;
+
+namespace Serilog.Sinks.ClickHouse.Tests.Integration;
+
+/// <summary>
+/// Verifies end-to-end that the sink tags its ClickHouse HTTP requests with the
+/// <c>lib</c> User-Agent token, by reading it back from <c>system.query_log</c>.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class UserAgentIntegrationTests
+{
+    private string ConnectionString => IntegrationTestFixture.ConnectionString;
+
+    [Test]
+    public async Task SinkQueries_AreTaggedWithLibInUserAgent()
+    {
+        var table = $"user_agent_{Guid.NewGuid():N}";
+        var options = new ClickHouseSinkOptions
+        {
+            ConnectionString = ConnectionString,
+            Schema = DefaultSchema.Create(table).Build(),
+        };
+
+        using (var sink = new ClickHouseSink(options))
+        {
+            await sink.EmitBatchAsync([new LogEventBuilder().WithMessage("user-agent probe").Build()]);
+        }
+
+        // Use a separate, untagged client for verification so the lib tag we assert on
+        // can only have come from the sink's own client.
+        using var client = new ClickHouseClient(ConnectionString);
+        await client.ExecuteNonQueryAsync("SYSTEM FLUSH LOGS");
+
+        var taggedQueryCount = await client.ExecuteScalarAsync(
+            "SELECT count() FROM system.query_log " +
+            $"WHERE query LIKE '%{table}%' " +
+            "AND http_user_agent LIKE '%lib:Serilog.Sinks.ClickHouse%' " +
+            "AND event_time > now() - INTERVAL 5 MINUTE");
+
+        Assert.That(Convert.ToInt64(taggedQueryCount), Is.GreaterThan(0),
+            "Expected the sink's queries to carry lib:Serilog.Sinks.ClickHouse in the HTTP User-Agent.");
+    }
+}

--- a/Serilog.Sinks.ClickHouse.Tests/Serilog.Sinks.ClickHouse.Tests.csproj
+++ b/Serilog.Sinks.ClickHouse.Tests/Serilog.Sinks.ClickHouse.Tests.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
     <PackageReference Include="nunit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
     <PackageReference Include="Testcontainers.ClickHouse" Version="4.10.0" />

--- a/Serilog.Sinks.ClickHouse.Tests/Unit/ClickHouseClientIdentityTests.cs
+++ b/Serilog.Sinks.ClickHouse.Tests/Unit/ClickHouseClientIdentityTests.cs
@@ -1,0 +1,61 @@
+using ClickHouse.Driver.ADO;
+
+namespace Serilog.Sinks.ClickHouse.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="ClickHouseClientIdentity"/>, which tags the ClickHouse
+/// client's User-Agent with this sink's library identity.
+/// </summary>
+public class ClickHouseClientIdentityTests
+{
+    [Test]
+    public void WithLibraryTag_SetsLibTagToLibraryName()
+    {
+        var settings = new ClickHouseClientSettings("Host=localhost");
+
+        var tagged = settings.WithLibraryTag();
+
+        Assert.That(tagged.ApplicationInfo, Contains.Key("lib"));
+        Assert.That(tagged.ApplicationInfo["lib"], Is.EqualTo(ClickHouseClientIdentity.LibraryName));
+    }
+
+    [Test]
+    public void WithLibraryTag_PreservesExistingApplicationInfoTags()
+    {
+        var settings = new ClickHouseClientSettings("Host=localhost")
+        {
+            ApplicationInfo = new Dictionary<string, string> { ["app"] = "MyApp", ["ver"] = "1.2.3" },
+        };
+
+        var tagged = settings.WithLibraryTag();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tagged.ApplicationInfo["app"], Is.EqualTo("MyApp"));
+            Assert.That(tagged.ApplicationInfo["ver"], Is.EqualTo("1.2.3"));
+            Assert.That(tagged.ApplicationInfo["lib"], Is.EqualTo(ClickHouseClientIdentity.LibraryName));
+        });
+    }
+
+    [Test]
+    public void WithLibraryTag_DoesNotMutateOriginalSettings()
+    {
+        var settings = new ClickHouseClientSettings("Host=localhost");
+
+        settings.WithLibraryTag();
+
+        Assert.That(settings.ApplicationInfo, Does.Not.ContainKey("lib"));
+    }
+
+    [Test]
+    public void CreateTaggedSettings_ParsesConnectionStringAndAppliesLibTag()
+    {
+        var settings = ClickHouseClientIdentity.CreateTaggedSettings("Host=example;Port=8123");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(settings.Host, Is.EqualTo("example"));
+            Assert.That(settings.ApplicationInfo["lib"], Is.EqualTo(ClickHouseClientIdentity.LibraryName));
+        });
+    }
+}

--- a/Serilog.Sinks.ClickHouse/ClickHouseClientIdentity.cs
+++ b/Serilog.Sinks.ClickHouse/ClickHouseClientIdentity.cs
@@ -1,0 +1,41 @@
+using ClickHouse.Driver.ADO;
+
+namespace Serilog.Sinks.ClickHouse;
+
+/// <summary>
+/// Tags the ClickHouse client's <c>User-Agent</c> with this sink's identity so that
+/// queries issued by the sink are attributable server-side via
+/// <see cref="ClickHouseClientSettings.ApplicationInfo"/> (ClickHouse.Driver 1.3.0+).
+/// </summary>
+internal static class ClickHouseClientIdentity
+{
+    /// <summary>
+    /// Value of the <c>lib</c> User-Agent tag identifying this library.
+    /// </summary>
+    internal const string LibraryName = "Serilog.Sinks.ClickHouse";
+
+    /// <summary>
+    /// Returns a copy of <paramref name="settings"/> with the <c>lib</c> tag set to
+    /// <see cref="LibraryName"/>, preserving any caller-supplied ApplicationInfo tags.
+    /// </summary>
+    internal static ClickHouseClientSettings WithLibraryTag(this ClickHouseClientSettings settings)
+    {
+        var applicationInfo = new Dictionary<string, string>();
+        if (settings.ApplicationInfo is not null)
+        {
+            foreach (var tag in settings.ApplicationInfo)
+            {
+                applicationInfo[tag.Key] = tag.Value;
+            }
+        }
+
+        applicationInfo["lib"] = LibraryName;
+        return new ClickHouseClientSettings(settings) { ApplicationInfo = applicationInfo };
+    }
+
+    /// <summary>
+    /// Builds client settings from a connection string with the <c>lib</c> tag applied.
+    /// </summary>
+    internal static ClickHouseClientSettings CreateTaggedSettings(string connectionString)
+        => new ClickHouseClientSettings(connectionString).WithLibraryTag();
+}

--- a/Serilog.Sinks.ClickHouse/ClickHouseSink.cs
+++ b/Serilog.Sinks.ClickHouse/ClickHouseSink.cs
@@ -33,7 +33,7 @@ public sealed class ClickHouseSink : IBatchedLogEventSink, IDisposable
     /// The sink creates and owns the <see cref="IClickHouseClient"/> internally.
     /// </summary>
     public ClickHouseSink(ClickHouseSinkOptions options)
-        : this(options, new ClickHouseClient(options.ConnectionString), ownsClient: true)
+        : this(options, new ClickHouseClient(ClickHouseClientIdentity.CreateTaggedSettings(options.ConnectionString)), ownsClient: true)
     {
     }
 

--- a/Serilog.Sinks.ClickHouse/Configuration/ClickHouseSinkExtensions.cs
+++ b/Serilog.Sinks.ClickHouse/Configuration/ClickHouseSinkExtensions.cs
@@ -4,6 +4,7 @@ using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.ClickHouse.Client;
 using Serilog.Sinks.ClickHouse.Schema;
+using SinkClientIdentity = Serilog.Sinks.ClickHouse.ClickHouseClientIdentity;
 
 namespace Serilog.Sinks.ClickHouse.Configuration;
 
@@ -229,7 +230,7 @@ public static class ClickHouseSinkExtensions
         ArgumentNullException.ThrowIfNull(loggerConfiguration);
         ArgumentNullException.ThrowIfNull(settings);
 
-        var client = new ClickHouseClient(settings);
+        var client = new ClickHouseClient(settings.WithLibraryTag());
         var options = CreateOptions(tableName, database, tableCreation, minimumLevel, formatProvider, onBatchWritten, onBatchFailed);
         options.Validate();
 

--- a/Serilog.Sinks.ClickHouse/Serilog.Sinks.ClickHouse.csproj
+++ b/Serilog.Sinks.ClickHouse/Serilog.Sinks.ClickHouse.csproj
@@ -42,9 +42,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClickHouse.Driver" Version="1.0.0"  />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.5" />
+    <PackageReference Include="ClickHouse.Driver" Version="1.3.0"  />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.8" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
## What

ClickHouse.Driver 1.3.0 adds `ClickHouseClientSettings.ApplicationInfo` — free-form tags appended to the HTTP `User-Agent` header for per-application query attribution. This sets the `lib` tag to `Serilog.Sinks.ClickHouse` on every client the sink constructs, so queries issued by this sink are attributable server-side.

## Changes

- Bump `ClickHouse.Driver` 1.0.0 → 1.3.0 (and `Microsoft.Extensions.Http` / `ObjectPool` 10.0.5 → 10.0.8 to satisfy the driver's transitive deps).
- Add internal `ClickHouseClientIdentity` helper that applies the `lib` tag while preserving any caller-supplied `ApplicationInfo` tags.
- Apply it on both the connection-string and `ClickHouseClientSettings` sink construction paths. Callers who pass a pre-built `IClickHouseClient` / `ClickHouseDataSource` are left untouched (the sink doesn't construct the client there).

## Testing

`dotnet build -c Release` succeeds with 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)